### PR TITLE
pass received coap packet on successful registration.

### DIFF
--- a/mbed-client/m2minterfaceobserver.h
+++ b/mbed-client/m2minterfaceobserver.h
@@ -49,7 +49,7 @@ public:
      * @param server_object, Object containing information about LWM2M server.
      * Client maintains the object.
      */
-    virtual void object_registered(M2MSecurity *security_object, const M2MServer &server_object) = 0;
+    virtual void object_registered(M2MSecurity *security_object, const M2MServer &server_object, sn_coap_hdr_s *coap_header) = 0;
 
     /**
      * @brief Callback informing that the device object has been unregistered

--- a/source/include/m2minterfaceimpl.h
+++ b/source/include/m2minterfaceimpl.h
@@ -141,7 +141,7 @@ protected: // From M2MNsdlObserver
                                     uint16_t data_len,
                                     sn_nsdl_addr_s *address_ptr);
 
-    virtual void client_registered(M2MServer *server_object);
+    virtual void client_registered(M2MServer *server_object, sn_coap_hdr_s*);
 
     void registration_updated(const M2MServer &server_object);
 

--- a/source/include/m2mnsdlobserver.h
+++ b/source/include/m2mnsdlobserver.h
@@ -46,7 +46,7 @@ public :
     * @param server_object, Server object associated with
     * registered server.
     */
-    virtual void client_registered(M2MServer *server_object) = 0;
+    virtual void client_registered(M2MServer *server_object, sn_coap_hdr_s *coap_header) = 0;
 
     /**
     * @brief Informs that client registration is updated successfully.

--- a/source/m2minterfaceimpl.cpp
+++ b/source/m2minterfaceimpl.cpp
@@ -265,13 +265,14 @@ void M2MInterfaceImpl::coap_message_ready(uint8_t *data_ptr,
     }
 }
 
-void M2MInterfaceImpl::client_registered(M2MServer *server_object)
+void M2MInterfaceImpl::client_registered(M2MServer *server_object, sn_coap_hdr_s *coap_header)
 {
     tr_debug("M2MInterfaceImpl::client_registered(M2MServer *server_object)");
     internal_event(STATE_REGISTERED);
+
     //Inform client is registered.
     //TODO: manage register object in a list.
-    _observer.object_registered(_register_server,*server_object);
+    _observer.object_registered(_register_server,*server_object, coap_header);
 }
 
 void M2MInterfaceImpl::registration_updated(const M2MServer &server_object)

--- a/source/m2mnsdlinterface.cpp
+++ b/source/m2mnsdlinterface.cpp
@@ -355,7 +355,8 @@ uint8_t M2MNsdlInterface::received_from_server_callback(struct nsdl_s * nsdl_han
                 _server = new M2MServer();
                 _server->set_resource_value(M2MServer::ShortServerID,1);
 
-                _observer.client_registered(_server);
+                _observer.client_registered(_server, coap_header);
+
                 // If lifetime is less than zero then leave the field empty
                 if(coap_header->options_list_ptr) {
                     if(coap_header->options_list_ptr->max_age_ptr) {


### PR DESCRIPTION
this change allows for passing the coap packet and thus the payload to the application layer. we need the payload, since it contains the assigned I2C address.
